### PR TITLE
Fix import syntax and package dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 'use strict';
-var React = require('react-native');
+import React, {Component, PropTypes} from 'react';
 
-var {
-  PropTypes,
+import {
   StyleSheet,
   TextInput,
   LayoutAnimation,
   Text,
   View,
-} = React;
+} from 'react-native';
 
 var FloatingLabel  = React.createClass({
 
@@ -19,7 +18,7 @@ var FloatingLabel  = React.createClass({
     disabled: PropTypes.bool,
     style: View.propTypes.style,
   },
-  
+
 
   getInitialState () {
     return {
@@ -74,8 +73,8 @@ var FloatingLabel  = React.createClass({
     }
 
     return (
-        <Text 
-          ref='label' 
+        <Text
+          ref='label'
           style={labelStyles}
         >
           {this.props.children}
@@ -136,28 +135,28 @@ var styles = StyleSheet.create({
     position: 'relative'
   },
   input: {
-    height: 40, 
-    borderColor: 'gray', 
+    height: 40,
+    borderColor: 'gray',
     backgroundColor: 'transparent',
     justifyContent: 'center',
-    borderWidth: 1, 
+    borderWidth: 1,
     color: 'black',
     fontSize: 20,
     borderRadius: 4,
     paddingLeft: 10,
     marginTop: 20,
-    
+
   },
-  labelClean: {    
-    marginTop: 21,    
+  labelClean: {
+    marginTop: 21,
     paddingLeft: 9,
     color: '#AAA',
     position: 'absolute',
     fontSize: 20,
     top: 7
   },
-  labelDirty: {    
-    marginTop: 21,   
+  labelDirty: {
+    marginTop: 21,
     paddingLeft: 9,
     color: '#AAA',
     position: 'absolute',
@@ -172,7 +171,7 @@ FloatingLabel.propTypes = {
 };
 
 var animations = {
-  layout: {    
+  layout: {
     easeInEaseOut: {
       duration: 200,
       create: {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,12 @@
   },
   "keywords": [
     "react-component",
-    "react-native",    
+    "react-native",
     "floating-labels",
     "ios"
   ],
   "dependencies": {
-    "lodash": "^3.8.0",
-    "react-native": "^0.4.1"
+    "lodash": "^3.8.0"
   },
   "author": "Mayank Patel",
   "license": "MIT"


### PR DESCRIPTION
@mayank-patel 
Hello Mayank, could you please check out the changes I made in the 'index.js' and 'package.json' files? 

The component you've created works great! However every time I run 'npm install' it duplicates react-native by creating a new folder in my projects node_modules folder. 
**(eg: project_name/node_modules/react-native-floating-labels/node_modules/react-native)** 
This leads me to delete the folder every time 'npm-install' is ran. To fix this I removed it from dependencies in 'package.json'. 

Also the 'index.js' file has depreciated syntax, I have to switch to the import syntax every time because it throws a Proptypes error. Proptypes now need to be imported from react instead of react-native. 

If there's anything you would like to ask me about these changes please email me at tomsok97@gmail.com. I'd be happy to hop into a google hangout to chat, hope to hear back!