### PR TITLE
Update render function. Use this.state.text rather than this.prop.value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ var FloatingLabel  = React.createClass({
         selectionState: this.props.selectionState,
         style: [styles.input],
         testID: this.props.testID,
-        value: this.props.value,
+        value: this.state.text,
         underlineColorAndroid: this.props.underlineColorAndroid, // android TextInput will show the default bottom border
         onKeyPress: this.props.onKeyPress
       },

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ var FloatingLabel  = React.createClass({
   getInitialState () {
     var state = {
       text: this.props.value,
-      dirty: !!this.props.value
+      dirty: (this.props.value || this.props.placeholder)
     };
 
     var style = state.dirty ? dirtyStyle : cleanStyle
@@ -131,6 +131,7 @@ var FloatingLabel  = React.createClass({
         onFocus: this._onFocus,
         onSubmitEditing: this.props.onSubmitEditing,
         password: this.props.secureTextEntry || this.props.password, // Compatibility
+        placeholder: this.props.placeholder,
         secureTextEntry: this.props.secureTextEntry || this.props.password, // Compatibility
         returnKeyType: this.props.returnKeyType,
         selectTextOnFocus: this.props.selectTextOnFocus,

--- a/index.js
+++ b/index.js
@@ -123,6 +123,7 @@ var FloatingLabel  = React.createClass({
         enablesReturnKeyAutomatically: this.props.enablesReturnKeyAutomatically,
         keyboardType: this.props.keyboardType,
         multiline: this.props.multiline,
+        numberOfLines: this.props.numberOfLines,
         onBlur: this._onBlur,
         onChange: this.props.onChange,
         onChangeText: this.onChangeText,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krazylabs/react-native-floating-labels",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Reusabe floating lable component for react native",
   "main": "index.js",
   "repository": {
@@ -18,7 +18,7 @@
     "lodash": "^3.8.0"
   },
   "scripts": {
-    "test": "echo 'Success'"  
+    "test": "echo 'Success'"
   },
   "author": "Mayank Patel",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-native-floating-labels",
+  "name": "@krazylabs/react-native-floating-labels",
   "version": "1.1.4",
   "description": "Reusabe floating lable component for react native",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mayank-patel/react-native-floating-labels.git"
+    "url": "https://github.com/KrazyLabs/react-native-floating-labels"
   },
   "keywords": [
     "react-component",


### PR DESCRIPTION
If the FloatingLabel value is set when the component is mounted the value cannot be changed currently. This is due to the fact that the underlying TextInput value is given the original prop value each time the render function is called. The end result is a value which cannot be modified.

getInitialState() always sets this.state.text  to this.props.value when the component is mounted. This PR simply uses the value of this.state.text within the render function.


 