### PR TITLE
Pass through more input properties.

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ var FloatingLabel  = createReactClass({
             onFocus: this._onFocus,
             style: [styles.input],
             value: this.state.text,
-            ref: inputRef
+            ref: this.props.inputRef || (_ => {})
         }),
         elementStyles = [styles.element];
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var FloatingLabel  = createReactClass({
     return state
   },
 
-  componentWillReceiveProps (props) {
+  UNSAFE_componentWillReceiveProps (props) {
     if (typeof props.value !== 'undefined' && props.value !== this.state.text) {
       this.setState({ text: props.value, dirty: !!props.value })
       this._animate(!!props.value)

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var propTypes = {
   labelStyle: textPropTypes.style,
   disabled: PropTypes.bool,
   style: ViewPropTypes.style,
+  inputRef: PropTypes.func,
 }
 
 var FloatingLabel  = createReactClass({
@@ -114,38 +115,18 @@ var FloatingLabel  = createReactClass({
   },
 
   render() {
-    var props = {
-        autoCapitalize: this.props.autoCapitalize,
-        autoCorrect: this.props.autoCorrect,
-        autoFocus: this.props.autoFocus,
-        bufferDelay: this.props.bufferDelay,
-        clearButtonMode: this.props.clearButtonMode,
-        clearTextOnFocus: this.props.clearTextOnFocus,
-        controlled: this.props.controlled,
-        editable: this.props.editable,
-        enablesReturnKeyAutomatically: this.props.enablesReturnKeyAutomatically,
-        keyboardType: this.props.keyboardType,
-        multiline: this.props.multiline,
-        numberOfLines: this.props.numberOfLines,
-        onBlur: this._onBlur,
-        onChange: this.props.onChange,
-        onChangeText: this.onChangeText,
-        onEndEditing: this.updateText,
-        onFocus: this._onFocus,
-        onSubmitEditing: this.props.onSubmitEditing,
-        password: this.props.secureTextEntry || this.props.password, // Compatibility
-        placeholder: this.props.placeholder,
-        secureTextEntry: this.props.secureTextEntry || this.props.password, // Compatibility
-        returnKeyType: this.props.returnKeyType,
-        selectTextOnFocus: this.props.selectTextOnFocus,
-        selectionState: this.props.selectionState,
-        style: [styles.input],
-        testID: this.props.testID,
-        value: this.state.text,
-        underlineColorAndroid: this.props.underlineColorAndroid, // android TextInput will show the default bottom border
-        onKeyPress: this.props.onKeyPress
-      },
-      elementStyles = [styles.element];
+    var filteredProps = Object.assign({}, this.props, {style : {}, children: null, inputRef : null});
+    var props = Object.assign({}, filteredProps,
+        {
+            onBlur: this._onBlur,
+            onChangeText: this.onChangeText,
+            onEndEditing: this.updateText,
+            onFocus: this._onFocus,
+            style: [styles.input],
+            value: this.state.text,
+            ref: inputRef
+        }),
+        elementStyles = [styles.element];
 
     if (this.props.inputStyle) {
       props.style.push(this.props.inputStyle);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-floating-labels",
-  "version": "1.1.8",
+  "name": "@webileapps/react-native-floating-labels",
+  "version": "1.2.0",
   "description": "Reusabe floating lable component for react native",
   "main": "index.js",
   "repository": {
@@ -17,6 +17,7 @@
   "dependencies": {
     "lodash": "^3.8.0"
   },
+  "files": ["index.js"],
   "scripts": {
     "test": "echo 'Success'"
   },


### PR DESCRIPTION
Only override properties that are required for label to float.

Support for inputRef property as `ref` property cannot be passed through to children.