### PR TITLE
Fix useNativeDriver warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ var FloatingLabel = createReactClass({
     return state
   },
 
-  componentWillReceiveProps(props) {
+  componentDidUpdate(props) {
     if (typeof props.value !== 'undefined' && props.value !== this.state.text) {
       this.setState({ text: props.value, dirty: !!props.value })
       this._animate(!!props.value)
@@ -57,7 +57,8 @@ var FloatingLabel = createReactClass({
         labelStyle[prop],
         {
           toValue: nextStyle[prop],
-          duration: 200
+          duration: 200,
+          useNativeDriver: false
         },
         Easing.ease
       )


### PR DESCRIPTION
I added `useNativeDriver: false`, and removed the following warning.

![image](https://user-images.githubusercontent.com/35623457/82009009-230e4a80-96a9-11ea-9116-f74974bb15f8.png)


