### PR TITLE
fix(demo): alias react/react-dom for Vite 8 / Rolldown compatibility

### DIFF
--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
   resolve: {
     alias: {
       'react-native': path.resolve(__dirname, 'node_modules/react-native-web'),
+      react: path.resolve(__dirname, 'node_modules/react'),
+      'react-dom': path.resolve(__dirname, 'node_modules/react-dom'),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Vite 8 switched from Rollup to Rolldown as its bundler
- Rolldown cannot resolve `react`/`react-dom` peer deps when processing files outside the demo project root (`../../src/index.tsx`)
- Adds explicit `resolve.alias` entries pointing both modules to `demo/node_modules/react` and `demo/node_modules/react-dom`

## Test plan

- [ ] CI passes on this PR
- [ ] Deploy Demo workflow succeeds after merge